### PR TITLE
Update 010

### DIFF
--- a/src/server/scripts/EasternKingdoms/BlackrockMountain/BlackrockSpire/instance_blackrock_spire.cpp
+++ b/src/server/scripts/EasternKingdoms/BlackrockMountain/BlackrockSpire/instance_blackrock_spire.cpp
@@ -415,11 +415,10 @@ public:
 
         void Dragonspireroomstore()
         {
-            uint8 creatureCount;
-
             for (uint8 i = 0; i < 7; ++i)
             {
-                creatureCount = 0;
+                // Refresh the creature list
+                runecreaturelist[i].clear();
 
                 if (GameObject* rune = instance->GetGameObject(go_roomrunes[i]))
                 {
@@ -430,10 +429,7 @@ public:
                         for (std::list<Creature*>::iterator itr = creatureList.begin(); itr != creatureList.end(); ++itr)
                         {
                             if (Creature* creature = *itr)
-                            {
-                                runecreaturelist[i][creatureCount] = creature->GetGUID();
-                                ++creatureCount;
-                            }
+                                runecreaturelist[i].push_back(creature->GetGUID());
                         }
                     }
                 }
@@ -454,9 +450,9 @@ public:
 
                 if (rune->GetGoState() == GO_STATE_ACTIVE)
                 {
-                    for (uint8 ii = 0; ii < 5; ++ii)
+                    for (ObjectGuid const& guid : runecreaturelist[i])
                     {
-                        mob = instance->GetCreature(runecreaturelist[i][ii]);
+                        mob = instance->GetCreature(guid);
                         if (mob && mob->IsAlive())
                             _mobAlive = true;
                     }
@@ -531,7 +527,7 @@ public:
             ObjectGuid go_blackrockaltar;
             ObjectGuid go_roomrunes[7];
             ObjectGuid go_emberseerrunes[7];
-            ObjectGuid runecreaturelist[7][5];
+            GuidVector runecreaturelist[7];
             ObjectGuid go_portcullis_active;
             ObjectGuid go_portcullis_tobossrooms;
             GuidList _incarceratorList;


### PR DESCRIPTION
Fix crash triggered during Dragonspire Hall event caused by having more than 5 mobs near a rune.
Crash added in 7c19fb8d0eae64db0719cc2b110fcc06f60542ac
Fix #26589

**Changes proposed**:

- 
- 
- 

**Target branch(es)**: 335/6x

**Issues addressed**: Fixes #

**Tests performed**: (Does it build, tested in-game, etc)

**Known issues and TODO list**:

- [ ] 
- [ ] 
